### PR TITLE
fix: remove redundant axon.serve call in miner.py

### DIFF
--- a/neurons/miner.py
+++ b/neurons/miner.py
@@ -102,7 +102,7 @@ class Miner(BaseNeuron):
                 verify_fn=allow_all
             )
 
-            self.axon.serve(netuid=self.settings.netuid, subtensor=self.settings.subtensor)
+            # self.axon.serve(netuid=self.settings.netuid, subtensor=self.settings.subtensor)
 
             self.axon.start()
             logger.info(f"Miner starting at block: {self.settings.subtensor.block}")


### PR DESCRIPTION
- Removed duplicate axon.serve() call since it's already handled by super().start()
- This prevents conflicts with the serve_extrinsic() logic in BaseNeuron