### PR TITLE
docs: simplify GraphQL agent fallback comment in miner env example

### DIFF
--- a/.env.miner.example
+++ b/.env.miner.example
@@ -15,5 +15,8 @@ MINER_LLM_MODEL=google/gemini-3-flash-preview
 # For project analysis
 LLM_MODEL=google/gemini-3-flash-preview
 
+# Fallback to Subql GraphQL Agent when no tools match
+ENABLE_FALL_BACK_GRAPHQL_AGENT=true
+
 # The Graph API token for querying subgraph data
 THEGRAPH_API_TOKEN=xx


### PR DESCRIPTION
- Make the comment more concise and readable
- Change from "When none of the tools are matched, the request will be redirected to the Subql GraphQL Agent" to "Fallback to Subql GraphQL Agent when no tools match"