### PR TITLE
Simplify subtensor network configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "network-hermes-subnet"
-version = "0.1.1"
+version = "0.1.2"
 description = "Add your description here"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
Fix issue-#12 

- Require SUBTENSOR_NETWORK environment variable to be set
- Remove fallback logic for 'local' network handling
- Update Metagraph initialization to use subtensor instance directly
- Simplify metagraph sync call by removing redundant subtensor parameter

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version bump to 0.1.2

* **Refactor**
  * Internal initialization and synchronization flow improvements with stricter configuration validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->